### PR TITLE
Add CGI.escape(path) to logical methods

### DIFF
--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -1,3 +1,5 @@
+require "CGI"
+
 require_relative "secret"
 require_relative "../client"
 require_relative "../request"
@@ -24,6 +26,7 @@ module Vault
     #
     # @return [Secret, nil]
     def read(path)
+      path = CGI.escape(path)
       json = client.get("/v1/#{path}")
       return Secret.decode(json)
     rescue HTTPError => e
@@ -44,6 +47,7 @@ module Vault
     #
     # @return [Secret]
     def write(path, data = {})
+      path = CGI.escape(path)
       json = client.put("/v1/#{path}", JSON.fast_generate(data))
       if json.nil?
         return true
@@ -63,6 +67,7 @@ module Vault
     #
     # @return [true]
     def delete(path)
+      path = CGI.escape(path)
       client.delete("/v1/#{path}")
       return true
     end


### PR DESCRIPTION
In case the path contains characters like '%' they should be URI-escaped. This will ensure the same behavior as the command line.

Example:

```
 vault read 'secret/user@%'
```

results in this HTTP request:

```
GET /v1/secret/user@%25 HTTP/1.1
Host: 127.0.0.1:8200
User-Agent: Go-http-client/1.1
X-Vault-Token: XXXXXX
Accept-Encoding: gzip
```

While using the same path with ruby-vault, resulted in the following error:

```
bad URI(is not URI?): /v1/secret/user@%
```

which comes from `/usr/lib/ruby/2.0.0/uri/common.rb:176` 

I considered putting this fix in `lib/vault/client.rb` in the `request` or `build_uri` methods. However, these methods support absolute URIs, which of course should not have the path escaped.
